### PR TITLE
Took some time this weekend to look into updating the dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
-project(big2-stack VERSION 0.0.9)
+project(big2-stack VERSION 0.0.10)
 
 set(USE_FOLDERS TRUE)
 set(CMAKE_FOLDER "BIG2")
@@ -28,7 +28,7 @@ cmake_dependent_option(BIG2_USE_IMGUI_DOCKING "Will use the docking branch of Im
 if(BIG2_USE_IMGUI_DOCKING)
     set(IMGUI_VERSION "docking")
 else()
-    set(IMGUI_VERSION "v1.89.4")
+    set(IMGUI_VERSION "v1.91.9b")
 endif ()
 
 include(cmake/utils.cmake)
@@ -36,6 +36,8 @@ include(cmake/utils.cmake)
 # Dependencies
 include(external/cmake-snippets/JsonDependency.cmake)
 json_config_dependencies(FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake-config.json" MEMBER_SELECTOR "dependencies")
+
+include(${CMAKE_BINARY_DIR}/_deps/bgfx-src/cmake/bgfxToolUtils.cmake)
 
 if("${BIG2_INCLUDE_IMGUI}")
     include(cmake/imgui.cmake)

--- a/big2/src/imgui/imgui_impl_bgfx.cpp
+++ b/big2/src/imgui/imgui_impl_bgfx.cpp
@@ -101,7 +101,7 @@ void ExecuteRenderCommands(const ImDrawData *draw_data, unsigned short view_id, 
 
         bgfx::setState(kState);
 
-        bgfx::TextureHandle texture = {static_cast<uint16_t>(reinterpret_cast<uintptr_t>(draw_command->TextureId) & 0xffff)};
+        bgfx::TextureHandle texture = {static_cast<uint16_t>(static_cast<uintptr_t>(draw_command->TextureId) & 0xffff)};
 
         bgfx::setTexture(0, texture_location, texture);
         bgfx::setVertexBuffer(0, &transient_vtx_buffer, 0, requested_vertices_count);
@@ -305,7 +305,7 @@ bool ImGui_ImplBgfx_CreateFontsTexture() {
   backend_data->font_texture_handle = bgfx::createTexture2D(texture_data.size.x, texture_data.size.y, kHasMips, kLayersCount, bgfx::TextureFormat::BGRA8, kFlags, data);
 
   ImGuiIO &io = ImGui::GetIO();
-  io.Fonts->SetTexID(reinterpret_cast<ImTextureID>(static_cast<std::uintptr_t>(backend_data->font_texture_handle.idx)));
+  io.Fonts->SetTexID(static_cast<ImTextureID>(backend_data->font_texture_handle.idx));
 
   return true;
 }

--- a/big2/src/imgui/imgui_impl_bgfx.cpp
+++ b/big2/src/imgui/imgui_impl_bgfx.cpp
@@ -101,7 +101,7 @@ void ExecuteRenderCommands(const ImDrawData *draw_data, unsigned short view_id, 
 
         bgfx::setState(kState);
 
-        bgfx::TextureHandle texture = {static_cast<uint16_t>(reinterpret_cast<intptr_t>(draw_command->TextureId) & 0xffff)};
+        bgfx::TextureHandle texture = {static_cast<uint16_t>(reinterpret_cast<uintptr_t>(draw_command->TextureId) & 0xffff)};
 
         bgfx::setTexture(0, texture_location, texture);
         bgfx::setVertexBuffer(0, &transient_vtx_buffer, 0, requested_vertices_count);
@@ -305,7 +305,7 @@ bool ImGui_ImplBgfx_CreateFontsTexture() {
   backend_data->font_texture_handle = bgfx::createTexture2D(texture_data.size.x, texture_data.size.y, kHasMips, kLayersCount, bgfx::TextureFormat::BGRA8, kFlags, data);
 
   ImGuiIO &io = ImGui::GetIO();
-  io.Fonts->SetTexID(reinterpret_cast<ImTextureID>(static_cast<std::intptr_t>(backend_data->font_texture_handle.idx)));
+  io.Fonts->SetTexID(reinterpret_cast<ImTextureID>(static_cast<std::uintptr_t>(backend_data->font_texture_handle.idx)));
 
   return true;
 }
@@ -315,7 +315,7 @@ void ImGui_ImplBgfx_DestroyFontsTexture() {
 
   if (isValid(backend_data->font_texture_handle)) {
     bgfx::destroy(backend_data->font_texture_handle);
-    ImGui::GetIO().Fonts->SetTexID(nullptr);
+    ImGui::GetIO().Fonts->SetTexID(0);
     backend_data->font_texture_handle = BGFX_INVALID_HANDLE;
   }
 }

--- a/cmake-config.json
+++ b/cmake-config.json
@@ -3,7 +3,7 @@
     {
       "name": "glfw",
       "url": "https://github.com/glfw/glfw.git",
-      "version": "3.3.8",
+      "version": "3.4",
       "options": [
         {
           "name": "GLFW_BUILD_EXAMPLES",
@@ -26,7 +26,7 @@
     {
       "name": "glm",
       "url": "https://github.com/g-truc/glm.git",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "options": [
         {
           "name": "GLM_ENABLE_CXX_20",
@@ -45,7 +45,7 @@
     {
       "name": "bgfx",
       "url": "https://github.com/bkaradzic/bgfx.cmake.git",
-      "version": "v1.125.8678-462",
+      "version": "v1.129.8866-492",
       "options": [
         {
           "name": "BGFX_BUILD_TOOLS",
@@ -69,12 +69,12 @@
     {
       "name": "microsoft-gsl",
       "url": "https://github.com/microsoft/GSL",
-      "version": "v4.0.0"
+      "version": "v4.2.0"
     },
     {
       "name": "spdlog",
       "url": "https://github.com/gabime/spdlog.git",
-      "version": "v1.11.0"
+      "version": "v1.15.2"
     }
   ]
 }

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -35,22 +35,24 @@ function(add_shaders_directory SHADERS_DIR TARGET_OUT_VAR)
 
     file(MAKE_DIRECTORY "${SHADERS_OUT_DIR}")
 
-    bgfx_compile_shader_to_header(
+    bgfx_compile_shaders(
             TYPE VERTEX
             SHADERS ${VERTEX_SHADER_FILES}
             VARYING_DEF "${VARYING_DEF_LOCATION}"
             OUTPUT_DIR "${SHADERS_OUT_DIR}"
             OUT_FILES_VAR VERTEX_OUTPUT_FILES
             INCLUDE_DIRS "${SHADERS_DIR}" "${BGFX_DIR}/src"
+            AS_HEADERS ON
     )
 
-    bgfx_compile_shader_to_header(
+    bgfx_compile_shaders(
             TYPE FRAGMENT
             SHADERS ${FRAGMENT_SHADER_FILES}
             VARYING_DEF "${VARYING_DEF_LOCATION}"
             OUTPUT_DIR "${SHADERS_OUT_DIR}"
             OUT_FILES_VAR FRAGMENT_OUTPUT_FILES
             INCLUDE_DIRS "${SHADERS_DIR}" "${BGFX_DIR}/src"
+            AS_HEADERS ON
     )
 
     set(OUTPUT_FILES)
@@ -64,8 +66,10 @@ function(add_shaders_directory SHADERS_DIR TARGET_OUT_VAR)
 
     set(INCLUDE_ALL_HEADER "")
     foreach(OUTPUT_FILE IN LISTS OUTPUT_FILES)
+        get_filename_component(FULL_PARENT_PATH ${OUTPUT_FILE} DIRECTORY)
+        get_filename_component(PARENT_DIR_NAME ${FULL_PARENT_PATH} NAME)
         get_filename_component(OUTPUT_FILENAME "${OUTPUT_FILE}" NAME)
-        string(APPEND INCLUDE_ALL_HEADER "#include <generated/shaders/${NAMESPACE}/${OUTPUT_FILENAME}>\n")
+        string(APPEND INCLUDE_ALL_HEADER "#include <generated/shaders/${NAMESPACE}/${PARENT_DIR_NAME}/${OUTPUT_FILENAME}>\n")
     endforeach()
     file(WRITE "${SHADERS_OUT_DIR}/all.h" "${INCLUDE_ALL_HEADER}")
     list(APPEND OUTPUT_FILES "${SHADERS_OUT_DIR}/all.h")


### PR DESCRIPTION
Did a little work this weekend to update dependencies to latest version of all.

The only thing I didn't like doing was in `cmake/utils.cmake`, where I had to explicitly add

```
get_filename_component(FULL_PARENT_PATH ${OUTPUT_FILE} DIRECTORY)
get_filename_component(PARENT_DIR_NAME ${FULL_PARENT_PATH} NAME)
```
Otherwise, when you create `all.h`, the includes are missing the rendering platform.